### PR TITLE
feat(dashboard): add dashboard with tabs and theming, plus tests

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:streamkeys/core/theme/bloc/theme_mode_bloc.dart';
+import 'package:streamkeys/core/theme/theme.dart';
+import 'package:streamkeys/service_locator.dart';
+
+class App extends StatelessWidget {
+  final Widget home;
+
+  const App({
+    super.key,
+    required this.home,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<ThemeModeBloc>(
+      create: (BuildContext context) => ThemeModeBloc(
+        ThemeModeRepository(sl<SharedPreferences>()),
+      ),
+      child: BlocBuilder<ThemeModeBloc, ThemeMode>(
+        builder: (BuildContext context, ThemeMode thememode) {
+          return MaterialApp(
+            title: 'StreamKeys',
+            themeMode: thememode,
+            theme: AppTheme.light,
+            darkTheme: AppTheme.dark,
+            home: home,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/core/constants/colors.dart
+++ b/lib/core/constants/colors.dart
@@ -5,7 +5,9 @@ class AppColors {
   /// Returns color palette for light theme.
   static const AppColorsData light = AppColorsData(
     primary: Color(0xFF5B5EFE),
+    onPrimary: Color(0xFFF1F1F1),
     danger: Color(0xFFFE5B5B),
+    onDanger: Color(0xFFF1F1F1),
     overlay: Color(0xFF9E9E9E),
     background: Color(0xFFF1F1F1),
     onBackground: Color(0xFF333333),
@@ -20,7 +22,9 @@ class AppColors {
   /// Returns color palette for dark theme.
   static const AppColorsData dark = AppColorsData(
     primary: Color(0xFF5B5EFE),
+    onPrimary: Color(0xFFF1F1F1),
     danger: Color(0xFFFE5B5B),
+    onDanger: Color(0xFFF1F1F1),
     overlay: Color(0xFF212121),
     background: Color(0xFF333333),
     onBackground: Color(0xFFF1F1F1),
@@ -42,7 +46,9 @@ class AppColors {
 
 class AppColorsData {
   final Color primary;
+  final Color onPrimary;
   final Color danger;
+  final Color onDanger;
   final Color overlay;
   final Color background;
   final Color onBackground;
@@ -55,7 +61,9 @@ class AppColorsData {
 
   const AppColorsData({
     required this.primary,
+    required this.onPrimary,
     required this.danger,
+    required this.onDanger,
     required this.overlay,
     required this.background,
     required this.onBackground,

--- a/lib/core/theme/components/index.dart
+++ b/lib/core/theme/components/index.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+import 'package:streamkeys/core/constants/colors.dart';
+
+part 'tab_bar_theme.dart';

--- a/lib/core/theme/components/tab_bar_theme.dart
+++ b/lib/core/theme/components/tab_bar_theme.dart
@@ -1,0 +1,21 @@
+part of 'index.dart';
+
+class AppTabThemeData {
+  const AppTabThemeData._();
+
+  static TabBarThemeData getTheme(AppColorsData colors) {
+    return TabBarThemeData(
+      dividerColor: Colors.transparent,
+      dividerHeight: 0,
+      labelColor: colors.onPrimary,
+      unselectedLabelColor: colors.onSurface,
+      tabAlignment: TabAlignment.fill,
+      indicatorSize: TabBarIndicatorSize.tab,
+      indicatorColor: Colors.transparent,
+      indicator: BoxDecoration(
+        color: colors.primary,
+      ),
+      // overlayColor: WidgetStatePropertyAll<Color>(colors.primary),
+    );
+  }
+}

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:streamkeys/core/constants/colors.dart';
+import 'package:streamkeys/core/theme/components/index.dart';
 
 class AppTheme {
   const AppTheme._();
@@ -17,6 +18,7 @@ class AppTheme {
         brightness: brightness,
       ),
       scaffoldBackgroundColor: colors.background,
+      tabBarTheme: AppTabThemeData.getTheme(colors),
     );
   }
 }

--- a/lib/desktop/desktop_main.dart
+++ b/lib/desktop/desktop_main.dart
@@ -4,6 +4,7 @@ import 'package:streamkeys/desktop/features/dashboard/presentation/screens/dashb
 import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
 import 'package:streamkeys/desktop/features/grid_deck/presentation/screens/grid_deck_screen.dart';
 import 'package:streamkeys/desktop/features/keyboard_deck/presentation/screens/keyboard_deck_screen.dart';
+import 'package:streamkeys/desktop/features/settings/presentation/screens/settings_screen.dart';
 import 'package:streamkeys/service_locator.dart';
 
 void desktopMain() async {
@@ -16,6 +17,7 @@ void desktopMain() async {
         tabs: <PageTab>[
           GridDeckScreen(),
           KeyboardDeckScreen(),
+          SettingsScreen(),
         ],
       ),
     ),

--- a/lib/desktop/desktop_main.dart
+++ b/lib/desktop/desktop_main.dart
@@ -1,11 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:streamkeys/app.dart';
 import 'package:streamkeys/desktop/features/dashboard/presentation/screens/dashboard_screen.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+import 'package:streamkeys/desktop/features/grid_deck/presentation/screens/grid_deck_screen.dart';
+import 'package:streamkeys/desktop/features/keyboard_deck/presentation/screens/keyboard_deck_screen.dart';
 import 'package:streamkeys/service_locator.dart';
 
 void desktopMain() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initServiceLocator();
 
-  runApp(const App(home: DashboardScreen()));
+  runApp(
+    const App(
+      home: DashboardScreen(
+        tabs: <PageTab>[
+          GridDeckScreen(),
+          KeyboardDeckScreen(),
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/desktop/desktop_main.dart
+++ b/lib/desktop/desktop_main.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:streamkeys/app.dart';
+import 'package:streamkeys/common/widgets/theme_mode_switch.dart';
+import 'package:streamkeys/core/theme/bloc/theme_mode_bloc.dart';
+import 'package:streamkeys/service_locator.dart';
+
+void desktopMain() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await initServiceLocator();
+
+  runApp(const App(home: HomeScreen()));
+}
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            BlocBuilder<ThemeModeBloc, ThemeMode>(
+              builder: (BuildContext context, ThemeMode thememode) {
+                return ThemeModeSwitch(
+                  themeMode: thememode,
+                  onChanged: (ThemeMode themeMode) {
+                    context
+                        .read<ThemeModeBloc>()
+                        .add(ThemeModeChange(themeMode));
+                  },
+                );
+              },
+            ),
+            const Text('StreamKeys'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/desktop/desktop_main.dart
+++ b/lib/desktop/desktop_main.dart
@@ -1,45 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:streamkeys/app.dart';
-import 'package:streamkeys/common/widgets/theme_mode_switch.dart';
-import 'package:streamkeys/core/theme/bloc/theme_mode_bloc.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/screens/dashboard_screen.dart';
 import 'package:streamkeys/service_locator.dart';
 
 void desktopMain() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initServiceLocator();
 
-  runApp(const App(home: HomeScreen()));
-}
-
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            BlocBuilder<ThemeModeBloc, ThemeMode>(
-              builder: (BuildContext context, ThemeMode thememode) {
-                return ThemeModeSwitch(
-                  themeMode: thememode,
-                  onChanged: (ThemeMode themeMode) {
-                    context
-                        .read<ThemeModeBloc>()
-                        .add(ThemeModeChange(themeMode));
-                  },
-                );
-              },
-            ),
-            const Text('StreamKeys'),
-          ],
-        ),
-      ),
-    );
-  }
+  runApp(const App(home: DashboardScreen()));
 }

--- a/lib/desktop/features/dashboard/presentation/screens/dashboard_screen.dart
+++ b/lib/desktop/features/dashboard/presentation/screens/dashboard_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:streamkeys/core/constants/colors.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/dashboard_tab_bar.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+import 'package:streamkeys/desktop/features/grid_deck/presentation/screens/grid_deck_screen.dart';
+import 'package:streamkeys/desktop/features/keyboard_deck/presentation/screens/keyboard_deck_screen.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  static final List<PageTab> tabs = <PageTab>[
+    const GridDeckScreen(),
+    const KeyboardDeckScreen(),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: tabs.length, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(45),
+        child: Container(
+          decoration: _boxDecoration(context),
+          child: DashboardTabBar(
+            tabs: tabs,
+            controller: _tabController,
+          ),
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: tabs.map((PageTab tab) => tab.pageView).toList(),
+      ),
+    );
+  }
+
+  BoxDecoration _boxDecoration(BuildContext context) {
+    return BoxDecoration(
+      border: Border(
+        bottom: BorderSide(
+          width: 4,
+          color: AppColors.of(context).outlineVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/desktop/features/dashboard/presentation/screens/dashboard_screen.dart
+++ b/lib/desktop/features/dashboard/presentation/screens/dashboard_screen.dart
@@ -2,11 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:streamkeys/core/constants/colors.dart';
 import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/dashboard_tab_bar.dart';
 import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
-import 'package:streamkeys/desktop/features/grid_deck/presentation/screens/grid_deck_screen.dart';
-import 'package:streamkeys/desktop/features/keyboard_deck/presentation/screens/keyboard_deck_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
-  const DashboardScreen({super.key});
+  final List<PageTab> tabs;
+
+  const DashboardScreen({
+    super.key,
+    required this.tabs,
+  });
 
   @override
   State<DashboardScreen> createState() => _DashboardScreenState();
@@ -16,15 +19,10 @@ class _DashboardScreenState extends State<DashboardScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
 
-  static final List<PageTab> tabs = <PageTab>[
-    const GridDeckScreen(),
-    const KeyboardDeckScreen(),
-  ];
-
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: tabs.length, vsync: this);
+    _tabController = TabController(length: widget.tabs.length, vsync: this);
   }
 
   @override
@@ -41,14 +39,14 @@ class _DashboardScreenState extends State<DashboardScreen>
         child: Container(
           decoration: _boxDecoration(context),
           child: DashboardTabBar(
-            tabs: tabs,
+            tabs: widget.tabs,
             controller: _tabController,
           ),
         ),
       ),
       body: TabBarView(
         controller: _tabController,
-        children: tabs.map((PageTab tab) => tab.pageView).toList(),
+        children: widget.tabs.map((PageTab tab) => tab.pageView).toList(),
       ),
     );
   }

--- a/lib/desktop/features/dashboard/presentation/widgets/dashboard_tab_bar.dart
+++ b/lib/desktop/features/dashboard/presentation/widgets/dashboard_tab_bar.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+
+class DashboardTabBar extends StatelessWidget {
+  final List<PageTab> tabs;
+  final TabController? controller;
+
+  const DashboardTabBar({
+    super.key,
+    required this.tabs,
+    this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TabBar(
+      controller: controller,
+      tabs: tabs.map((PageTab tab) {
+        return Tab(
+          height: 35,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 8,
+            children: <Widget>[
+              Icon(tab.iconData, size: 18),
+              Text(tab.label),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/desktop/features/dashboard/presentation/widgets/page_tab.dart
+++ b/lib/desktop/features/dashboard/presentation/widgets/page_tab.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/cupertino.dart';
+
+mixin PageTab {
+  Widget get pageView;
+  String get label;
+  IconData get iconData;
+}

--- a/lib/desktop/features/grid_deck/presentation/screens/grid_deck_screen.dart
+++ b/lib/desktop/features/grid_deck/presentation/screens/grid_deck_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+
+class GridDeckScreen extends StatelessWidget with PageTab {
+  const GridDeckScreen({super.key});
+
+  @override
+  Widget get pageView => this;
+
+  @override
+  String get label => 'Grid Deck';
+
+  @override
+  IconData get iconData => Icons.grid_view;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(label),
+    );
+  }
+}

--- a/lib/desktop/features/keyboard_deck/presentation/screens/keyboard_deck_screen.dart
+++ b/lib/desktop/features/keyboard_deck/presentation/screens/keyboard_deck_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+
+class KeyboardDeckScreen extends StatelessWidget with PageTab {
+  const KeyboardDeckScreen({super.key});
+
+  @override
+  Widget get pageView => this;
+
+  @override
+  String get label => 'Keyboard Deck';
+
+  @override
+  IconData get iconData => Icons.keyboard_outlined;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(label),
+    );
+  }
+}

--- a/lib/desktop/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/desktop/features/settings/presentation/screens/settings_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+
+class SettingsScreen extends StatelessWidget with PageTab {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget get pageView => this;
+
+  @override
+  String get label => 'Settings';
+
+  @override
+  IconData get iconData => Icons.settings;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(label),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,55 +1,5 @@
-import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:streamkeys/common/widgets/theme_mode_switch.dart';
-import 'package:streamkeys/core/theme/bloc/theme_mode_bloc.dart';
-import 'package:streamkeys/core/theme/theme.dart';
-import 'package:streamkeys/service_locator.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:streamkeys/desktop/desktop_main.dart';
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await initServiceLocator();
-
-  runApp(const App());
-}
-
-class App extends StatelessWidget {
-  const App({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocProvider<ThemeModeBloc>(
-      create: (BuildContext context) => ThemeModeBloc(
-        ThemeModeRepository(sl<SharedPreferences>()),
-      ),
-      child: BlocBuilder<ThemeModeBloc, ThemeMode>(
-        builder: (BuildContext context, ThemeMode thememode) {
-          return MaterialApp(
-            title: 'StreamKeys',
-            themeMode: thememode,
-            theme: AppTheme.light,
-            darkTheme: AppTheme.dark,
-            home: Scaffold(
-              body: Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    ThemeModeSwitch(
-                      themeMode: thememode,
-                      onChanged: (ThemeMode themeMode) {
-                        context
-                            .read<ThemeModeBloc>()
-                            .add(ThemeModeChange(themeMode));
-                      },
-                    ),
-                    const Text('StreamKeys'),
-                  ],
-                ),
-              ),
-            ),
-          );
-        },
-      ),
-    );
-  }
+void main() {
+  desktopMain();
 }

--- a/test/dashboard/dashboard_screen_test.dart
+++ b/test/dashboard/dashboard_screen_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/screens/dashboard_screen.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+
+import 'page_tab_mock.dart';
+
+void main() {
+  testWidgets(
+    'DashboardScreen renders and switches between tabs',
+    (WidgetTester tester) async {
+      final List<PageTab> mockTabs = <PageTab>[
+        const PageTabMock(
+          label: 'Grid',
+          iconData: Icons.grid_view,
+        ),
+        const PageTabMock(
+          label: 'Keyboard',
+          iconData: Icons.keyboard,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DashboardScreen(tabs: mockTabs),
+        ),
+      );
+
+      expect(find.text('Page: Grid'), findsOneWidget);
+      expect(find.text('Page: Keyboard'), findsNothing);
+
+      await tester.tap(find.byType(Tab).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page: Grid'), findsNothing);
+      expect(find.text('Page: Keyboard'), findsOneWidget);
+    },
+  );
+}

--- a/test/dashboard/page_tab_mock.dart
+++ b/test/dashboard/page_tab_mock.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:streamkeys/desktop/features/dashboard/presentation/widgets/page_tab.dart';
+
+class PageTabMock extends StatelessWidget with PageTab {
+  @override
+  Widget get pageView => this;
+
+  @override
+  final String label;
+
+  @override
+  final IconData iconData;
+
+  const PageTabMock({
+    super.key,
+    required this.label,
+    required this.iconData,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('Page: $label');
+  }
+}


### PR DESCRIPTION
### Pull Request Description

* Refactor `main.dart` by moving app initialization logic to `app.dart` and desktop-specific entry point to `desktop_main.dart`.
* Implement `DashboardScreen` with tab navigation and a reusable `DashboardTabBar` widget.
* Introduce `AppTabThemeData` for customizable tab bar theming.
* Extend `AppColorsData` with new color properties: `onPrimary` and `onDanger`.
* Add unit tests for `DashboardScreen` and a mock class `PageTabMock` to ensure coverage of tab-related logic.