### PR TITLE
chore(update-github-updater): replace github_apk_updater with github_updater and update imports

### DIFF
--- a/lib/core/app_update/data/services/app_update_service.dart
+++ b/lib/core/app_update/data/services/app_update_service.dart
@@ -1,17 +1,17 @@
+import 'package:github_updater/github_updater.dart';
 import 'package:streamkeys/core/constants/version.dart';
 import 'package:streamkeys/core/app_update/data/services/app_update_preferences.dart';
 import 'package:streamkeys/core/app_update/data/services/windows_updater_launcher.dart';
-import 'package:github_apk_updater/github_apk_updater.dart';
 
 class AppUpdateService {
   final AppUpdatePreferences preferences;
   final WindowsUpdaterLauncher windowsUpdaterLauncher;
-  final GithubApkUpdater githubApkUpdater;
+  final GithubUpdater githubUpdater;
 
   const AppUpdateService({
     required this.preferences,
     required this.windowsUpdaterLauncher,
-    required this.githubApkUpdater,
+    required this.githubUpdater,
   });
 
   String? getIgnoredVersion() {
@@ -26,7 +26,7 @@ class AppUpdateService {
     final currentVersion = getCurrentVersion();
     final currentVersionMode = getCurrentVersionMode();
 
-    final latest = await githubApkUpdater.releaseService.fetchLatestRelease(
+    final latest = await githubUpdater.fetchLatestRelease(
       mode: currentVersionMode,
     );
 

--- a/lib/core/app_update/data/services/windows_updater_launcher.dart
+++ b/lib/core/app_update/data/services/windows_updater_launcher.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:github_apk_updater/github_apk_updater.dart';
+import 'package:github_updater/github_updater.dart';
 import 'package:streamkeys/desktop/utils/process_runner.dart';
 
 class WindowsUpdaterLauncher {

--- a/lib/core/app_update/presentation/widgets/update_dialog.dart
+++ b/lib/core/app_update/presentation/widgets/update_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:github_apk_updater/github_apk_updater.dart';
+import 'package:github_updater/github_updater.dart';
 import 'package:streamkeys/core/constants/spacing.dart';
 import 'package:streamkeys/core/constants/typography.dart';
 import 'package:streamkeys/service_locator.dart';

--- a/lib/core/constants/version.dart
+++ b/lib/core/constants/version.dart
@@ -1,4 +1,4 @@
-import 'package:github_apk_updater/github_apk_updater.dart';
+import 'package:github_updater/github_updater.dart';
 
 class AppVersion {
   static const String appVersion = 'v3.0.0';

--- a/lib/mobile/features/app_update/bloc/apk_download_bloc.dart
+++ b/lib/mobile/features/app_update/bloc/apk_download_bloc.dart
@@ -9,10 +9,11 @@ class ApkDownloadBloc extends Bloc<ApkDownloadEvent, ApkDownloadState> {
   final AppUpdateService appUpdateService;
 
   ApkDownloadBloc(this.appUpdateService) : super(const ApkDownloadState()) {
-    appUpdateService.githubApkUpdater.apkDownloader.downloadProgressStream
-        .listen((progress) {
-          add(ApkDownloadUpdateProgress(progress));
-        });
+    appUpdateService.githubUpdater.downloader.downloadProgressStream.listen((
+      progress,
+    ) {
+      add(ApkDownloadUpdateProgress(progress));
+    });
 
     on<ApkDownloadUpdateProgress>((event, emit) {
       emit(ApkDownloadState(event.progress));

--- a/lib/mobile/features/app_update/presentation/screens/update_screen.dart
+++ b/lib/mobile/features/app_update/presentation/screens/update_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:github_apk_updater/models/github_release_info.dart';
+import 'package:github_updater/github_updater.dart';
 import 'package:streamkeys/core/constants/spacing.dart';
 import 'package:streamkeys/core/constants/typography.dart';
 import 'package:streamkeys/mobile/features/app_update/bloc/apk_download_bloc.dart';

--- a/lib/mobile/features/app_update/presentation/widgets/show_release_dialog.dart
+++ b/lib/mobile/features/app_update/presentation/widgets/show_release_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:github_apk_updater/widgets/show_update_dialog.dart';
+import 'package:github_updater/widgets/show_update_dialog.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:streamkeys/core/constants/version.dart';
@@ -12,7 +12,7 @@ void showReleaseDialog(BuildContext context, {bool showDialogForce = false}) {
   final ignoredVersion = appUpdate.preferences.loadIgnoredVersion();
   showUpdateDialog(
     context,
-    apkUpdater: appUpdate.githubApkUpdater,
+    apkUpdater: appUpdate.githubUpdater,
     currentVersion: AppVersion.appVersion,
     ignoredVersion: showDialogForce == true ? null : ignoredVersion,
     onUpdate: (releaseInfo) async {
@@ -28,13 +28,13 @@ void showReleaseDialog(BuildContext context, {bool showDialogForce = false}) {
             builder: (_) => UpdateScreen(
               releaseInfo: releaseInfo,
               onInit: () {
-                appUpdate.githubApkUpdater.apkDownloader.start(
+                appUpdate.githubUpdater.downloader.start(
                   asset.browserDownloadUrl,
                   filePath,
                 );
               },
               onUpdated: () {
-                appUpdate.githubApkUpdater.installApk(filePath);
+                appUpdate.githubUpdater.installApk(filePath);
               },
             ),
           ),

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get_it/get_it.dart';
-import 'package:github_apk_updater/github_apk_updater.dart';
+import 'package:github_updater/github_updater.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:streamkeys/core/storage/generic_secure_storage.dart';
 import 'package:streamkeys/core/app_update/data/services/app_update_preferences.dart';
@@ -54,7 +54,7 @@ Future<void> initServiceLocator() async {
 
   final appUpdateService = AppUpdateService(
     preferences: AppUpdatePreferences(sharedPreferences),
-    githubApkUpdater: GithubApkUpdater(repo: 'yevheniy-hliebov/StreamKeys'),
+    githubUpdater: GithubUpdater(repo: 'yevheniy-hliebov/StreamKeys'),
     windowsUpdaterLauncher: WindowsUpdaterLauncher(),
   );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -488,13 +488,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.3"
-  github_apk_updater:
+  github_updater:
     dependency: "direct main"
     description:
       path: "."
       ref: main
-      resolved-ref: "7068d9534f05d584ce67292d32ce2787f25fb45f"
-      url: "https://github.com/yevheniy-hliebov/github_apk_updater.git"
+      resolved-ref: "53e3a0db4478761550b3978d280e67e6bdc18eb7"
+      url: "https://github.com/yevheniy-hliebov/github_updater.git"
     source: git
     version: "0.0.2"
   glob:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,9 +44,9 @@ dependencies:
   args: ^2.7.0
   archive: ^4.0.7
   flutter_markdown_plus: ^1.0.3
-  github_apk_updater:
+  github_updater:
     git:
-      url: https://github.com/yevheniy-hliebov/github_apk_updater.git
+      url: https://github.com/yevheniy-hliebov/github_updater.git
       ref: main
 
 dev_dependencies:

--- a/test/app_update/updater_launcher_test.dart
+++ b/test/app_update/updater_launcher_test.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:github_apk_updater/github_apk_updater.dart';
+import 'package:github_updater/github_updater.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:streamkeys/core/app_update/data/services/windows_updater_launcher.dart';


### PR DESCRIPTION
- Updated dependency in pubspec: `github_apk_updater` → `github_updater`
- Fixed imports to use the new package
- Adjusted related code to match the updated package API
- No user-facing functionality changes, only package integration updates